### PR TITLE
Fix multibyte strings printing

### DIFF
--- a/binary_search.go
+++ b/binary_search.go
@@ -128,6 +128,8 @@ func (search *BinarySearch) PrintMatch(start int64, match string) {
 		search.file.Seek(start, os.SEEK_SET)
 	}
 	data := make([]byte, 1)
+	var full_data []byte
+
 	for count := 0; start >= 0 && search.Compare(match) == 0; count++ {
 		search.file.Seek(start, os.SEEK_SET)
 		var isEof = false
@@ -137,7 +139,7 @@ func (search *BinarySearch) PrintMatch(start int64, match string) {
 				break
 			}
 			start++
-			fmt.Printf("%s", string(data[0]))
+			full_data = append(full_data, data[0])
 			if data[0] == '\n' {
 				break
 			}
@@ -146,6 +148,7 @@ func (search *BinarySearch) PrintMatch(start int64, match string) {
 			break
 		}
 	}
+	fmt.Printf("%s", string(full_data))
 
 }
 


### PR DESCRIPTION
When matching data contains multibyte strings (e.g. UTF-8 encoded strings), PrintMatch prints an incorrect interpretation of the data, as bytes are decoded to string and printed one by one.

By appending all bytes to a single byte slice and decoding to string the full slice as a whole, multibyte characters are correctly interpreted.

Example of incorrect output (UTF-8 encoded file):
silÃ¡m

Example of correct output (UTF-8 encoded file):
silám